### PR TITLE
Log postmessages as debug level and with data as object

### DIFF
--- a/js/postMessage-debugger.js
+++ b/js/postMessage-debugger.js
@@ -1,10 +1,11 @@
-var postMessageDebugger = {
-  init: function() {
-    console.log("postMessageDebugger activated");
-    addEventListener("message", function(event) {
-      console.log(document.title + " received '" + event.data + "'")
-    });
-  }
-};
-
-postMessageDebugger.init();
+console.debug("postMessageDebugger activated");
+addEventListener("message", function(event) {
+  console.debug(
+    "postMessage received by '" +
+      document.title +
+      "' from '" +
+      event.origin +
+      "' with data:",
+    event.data
+  );
+});

--- a/manifest.json
+++ b/manifest.json
@@ -2,13 +2,15 @@
   "manifest_version": 2,
   "name": "postMessage debugger",
   "description": "This extension prints messages sent with postMessage to the console",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "browser_action": {
     "name": "Debug postMessages"
   },
-  "content_scripts": [ {
-    "js": [ "js/postMessage-debugger.js" ],
-    "matches": [ "http://*/*", "https://*/*" ],
-    "all_frames": true
-  }]
+  "content_scripts": [
+    {
+      "js": ["js/postMessage-debugger.js"],
+      "matches": ["http://*/*", "https://*/*"],
+      "all_frames": true
+    }
+  ]
 }


### PR DESCRIPTION
Thanks for an excellent chrome extension!

This change makes it possible to debug when `event.data` is an object.
Previous behaviour logs it as `[Object object]` in the log since it is expected to be a string.
Bumped the version number also.
